### PR TITLE
B2g gingerbread

### DIFF
--- a/rootdir/init.rc.gonk
+++ b/rootdir/init.rc.gonk
@@ -341,10 +341,10 @@ service rilproxy /system/bin/rilproxy
     user root
     group radio cache inet misc audio sdcard_rw net_admin net_raw log
 
-service media /system/bin/mediaserver
-    user media
-    group system audio camera graphics inet net_bt net_bt_admin net_raw
-    ioprio rt 4
+#service media /system/bin/mediaserver
+#    user media
+#    group system audio camera graphics inet net_bt net_bt_admin net_raw
+#    ioprio rt 4
 
 service bootanim /system/bin/bootanimation
     user graphics


### PR DESCRIPTION
The mediaserver should not be need by QEMU gonk build.
It was only borrowed SGS2 gonk to talk with proprietary audio libraries.
